### PR TITLE
Bugfix

### DIFF
--- a/discord_bots/commands.py
+++ b/discord_bots/commands.py
@@ -1008,7 +1008,7 @@ def map_status_str(full_status: bool) -> str:
                                                                                Map.id != current_map_id).order_by(
                         Map.rotation_index.asc()).all()  # type: ignore
                     next_map = next(filter(lambda x: x.rotation_index > current_rotation_index, other_rotation_maps),
-                                    None) or other_rotation_maps[0]
+                                    current_map_full) or other_rotation_maps[0]
                     first_rotation_map: Map = session.query(Map).filter(Map.rotation_weight > 0).order_by(
                         Map.rotation_index.asc()).first()  # type: ignore
                     if first_rotation_map and current_rotation_index == first_rotation_map.rotation_index:

--- a/discord_bots/commands.py
+++ b/discord_bots/commands.py
@@ -1101,11 +1101,24 @@ async def add(ctx: Context, *args):
                 # Try adding by integer index first, then try string name
                 try:
                     queue_index = int(arg) - 1
+                    if queue_index >= len(all_queues):
+                        await send_message(
+                            ctx.message.channel,
+                            embed_description="No valid queues found",
+                            colour=Colour.red(),
+                        )
+                        return
                     queues_to_add.append(all_queues[queue_index])
                 except ValueError:
                     queue: Queue | None = session.query(Queue).filter(Queue.name.ilike(arg)).first()  # type: ignore
-                    if queue:
-                        queues_to_add.append(queue)
+                    if queue is None:
+                        await send_message(
+                            ctx.message.channel,
+                            embed_description="No valid queues found",
+                            colour=Colour.red(),
+                        )
+                        return
+                    queues_to_add.append(queue)
                 except IndexError:
                     continue
 


### PR DESCRIPTION
Bug 1: Bot breaks if there are not at least 2 maps in rotation (rotation weight 0 = not in rotation)

- When there was one map, next returned None which was later accessed.

Bug 2: There is an error thrown (logfile/sconsole) when adding by index>queue count (e.g. !add 6)

- Both adding by index and name now don't throw an exception in the log/file as well as they remind the user of invalid add.